### PR TITLE
ブロック抽選のバグ修正

### DIFF
--- a/app/src/main/java/com/example/tetris/blocks.java
+++ b/app/src/main/java/com/example/tetris/blocks.java
@@ -37,10 +37,10 @@ public class blocks {
             }
         }else {
             if (randomNumbers.size() <= 2) {
+                Collections.shuffle(blockNumbers);
                 for (int i = 2; i < 6; i++) {
                     randomNumbers.add(i, blockNumbers.get(i));
                 }
-                Collections.shuffle(randomNumbers);
             }
         }
     }

--- a/app/src/main/java/com/example/tetris/blocks.java
+++ b/app/src/main/java/com/example/tetris/blocks.java
@@ -26,15 +26,22 @@ public class blocks {
     static int[][] nextBlock = new int[blockLenght][blockLenght];
     static List<Integer> blockNumbers = Arrays.asList(1, 2, 3, 4, 5, 6, 7);
     static List<Integer> randomNumbers = new ArrayList<>();
+    static boolean firsttime=false;
 
 
     //ブロックのランダム処理
     public static void randomNumber() {
-        if (randomNumbers.size() <= 2) {
-            for (int i = 0; i < 6; i++) {
+        if(!firsttime){
+            for(int i=0;i<6;i++){
                 randomNumbers.add(blockNumbers.get(i));
             }
-            Collections.shuffle(randomNumbers);
+        }else {
+            if (randomNumbers.size() <= 2) {
+                for (int i = 2; i < 6; i++) {
+                    randomNumbers.add(i, blockNumbers.get(i));
+                }
+                Collections.shuffle(randomNumbers);
+            }
         }
     }
 


### PR DESCRIPTION
## 概要

ブロック抽選のバグ修正

## 変更点


- randomNuberの処理が一回目、２回目以降で処理を分ける
- １回目はrandomNubersにblockNumbersを代入
- ２回目はrandomNUbers.sizeが２以下の時blockNumbersをシャッフル、randomNumbersの３個目以降に代入する

## Issue

closed #58 
